### PR TITLE
Switched containerId to use name not the actual containerId.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ function startCollection() {
   Stats(statOpts).pipe(through.obj(function(chunk, enc, cb) {
     var maxMemoryUsage = chunk.stats.memory_stats.max_usage;
     var memoryUsage = chunk.stats.memory_stats.usage;
-    var containerId = chunk.id;
+    var containerId = chunk.name;
     var image = chunk.image;
     client.gauge('container.memory', memoryUsage, {container: containerId, image: image});
     client.gauge('container.memory.max', maxMemoryUsage, {container: containerId, image: image});
-    this.push('Usage: '+ memoryUsage +' Max Usage: ' + maxMemoryUsage + ' for container: ' + containerId + ' image: ' + image);
+    this.push('Usage: '+ memoryUsage +' Max Usage: ' + maxMemoryUsage + ' for container: ' + containerId + ' image:' + image);
     this.push('\n');
     cb();
   })).pipe(process.stdout); 


### PR DESCRIPTION
In an effort to monitor memory usage for a zetta instance I switched the containerId to use the `name` instead of `id`. I'm doing this mainly due to the limitations in CloudWatch. With our zetta instances restarting every so often and the inability to CloudWatch to join custom metrics it's very hard to get a sense of the memory usage of a particular instance over a long period of time. With this PR each target docker container will be a continuous metric for the life of the ec2 instance.

We can revert back to sending containerId if we decide to move away from CloudWatch.